### PR TITLE
Fix relative word frequencies graph in section 2.4

### DIFF
--- a/02-tidy-text.Rmd
+++ b/02-tidy-text.Rmd
@@ -180,16 +180,23 @@ Now, let's calculate the frequency for each word for the works of Jane Austen, t
 ```{r frequency, dependson = c("tidy_bronte", "tidy_hgwells", "tidy_books")}
 tidy_both <- bind_rows(
   mutate(tidy_bronte, author = "Brontë Sisters"),
-  mutate(tidy_hgwells, author = "H.G. Wells"))
-frequency <- tidy_both %>%
+  mutate(tidy_hgwells, author = "H.G. Wells")) %>%
   mutate(word = str_extract(word, "[a-z]+")) %>%
   count(author, word) %>%
   rename(other = n) %>%
-  inner_join(count(tidy_books, word)) %>%
-  rename(Austen = n) %>%
-  mutate(other = other / sum(other),
-         Austen = Austen / sum(Austen)) %>%
-  ungroup()
+  group_by(author) %>% 
+  mutate(sum_other = sum(other)) %>% 
+  ungroup() 
+tidy_Austen <- tidy_books %>% 
+  mutate(word = str_extract(word, "[a-z]+")) %>% 
+  count(word) %>% 
+  rename(Austen = n) %>% 
+  mutate(sum_Austen = sum(Austen)) 
+frequency <- tidy_both %>%
+  inner_join(tidy_Austen) %>% 
+  filter(!is.na(word)) %>% 
+  mutate(other = other / sum_other,
+         Austen = Austen / sum_Austen) 
 ```
 
 We use `str_extract` here because the UTF-8 encoded texts from Project Gutenberg have some examples of words with underscores around them to indicate emphasis (like italics). The tokenizer treated these as words but we don't want to count "\_any\_" separately from "any". Now let's plot.

--- a/02-tidy-text.Rmd
+++ b/02-tidy-text.Rmd
@@ -210,7 +210,7 @@ ggplot(frequency, aes(x = other, y = Austen, color = abs(Austen - other))) +
   scale_x_log10(labels = percent_format()) +
   scale_y_log10(labels = percent_format()) +
   scale_color_gradient(limits = c(0, 0.001), low = "darkslategray4", high = "gray75") +
-  facet_wrap(~author, ncol = 2) +
+  facet_wrap(~author, ncol = 2, scales = "free_x") +
   theme(legend.position="none") +
   labs(y = "Jane Austen", x = NULL)
 ```


### PR DESCRIPTION
There are two commits which make the relative word frequencies graph at the end of section 2.4 a little bit better.

The first commit calculates the denominator for relative word frequencies before joining datasets; otherwise, the `inner_join()` will exclude some words from each of the authors, thereby reducing the denominator (especially important for Austen).

The second commit is a small improvement by reducing the whitespace in the faceted graph.