### PR TITLE
loughran replaced with bing dictionary to remove errors during pdf compilation

### DIFF
--- a/05-document-term-matrices.Rmd
+++ b/05-document-term-matrices.Rmd
@@ -373,7 +373,7 @@ The Loughran data divides words into six sentiments: "positive", "negative", "li
 ```{r stockloughransentiments, fig.cap = "The most common words in the financial news articles associated with each of the six sentiments in the Loughran and McDonald lexicon"}
 stock_tokens %>%
   count(word) %>%
-  inner_join(get_sentiments("loughran"), by = "word") %>%
+  inner_join(get_sentiments("bing"), by = "word") %>%
   group_by(sentiment) %>%
   top_n(5, n) %>%
   ungroup() %>%
@@ -391,7 +391,7 @@ Now that we know we can trust the dictionary to approximate the articles' sentim
 
 ```{r}
 stock_sentiment_count <- stock_tokens %>%
-  inner_join(get_sentiments("loughran"), by = "word") %>%
+  inner_join(get_sentiments("bing"), by = "word") %>%
   count(sentiment, company) %>%
   spread(sentiment, n, fill = 0)
 


### PR DESCRIPTION
I get this error on the main book when I try to compile it to pdf (after changing the default) in _build.sh. Changing the dict to bing from loughran fixes this error. Error below:

"
label: stockloughransentiments (with options) 
List of 1
 $ fig.cap: chr "The most common words in the financial news articles associated with each of the six sentiments in the Loughran"| __truncated__

Quitting from lines 374-386 (05-document-term-matrices.Rmd) 
Error in match.arg(lexicon) : 
  'arg' should be one of "afinn", "bing", "nrc"
Calls: local ... same_src.data.frame -> is.data.frame -> get_sentiments -> match.arg

Execution halted
Error in Rscript_render(f, render_args, render_meta) : 
  Failed to compile 05-document-term-matrices.Rmd
Calls: <Anonymous> -> render_new_session -> Rscript_render
Execution halted
"