### PR TITLE
Section length is 80, not 100 lines

### DIFF
--- a/02-sentiment-analysis.Rmd
+++ b/02-sentiment-analysis.Rmd
@@ -90,7 +90,7 @@ We see many positive, happy words about hope, friendship, and love here.
 
 Or instead we could examine how sentiment changes throughout each novel. We can do this with just a handful of lines that are mostly dplyr functions. First, we find a sentiment score for each word using the Bing lexicon and `inner_join()`. 
 
-Next, we count up how many positive and negative words there are in defined sections of each book. We define an `index` here to keep track of where we are in the narrative; this index (using integer division) counts up sections of 100 lines of text.
+Next, we count up how many positive and negative words there are in defined sections of each book. We define an `index` here to keep track of where we are in the narrative; this index (using integer division) counts up sections of 80 lines of text.
 
 ```{block, type = "rmdtip"}
 The `%/%` operator does integer division (`x %/% y` is equivalent to `floor(x/y)`) so the index keeps track of which 80-line section of text we are counting up negative and positive sentiment in. 


### PR DESCRIPTION
Sentiment analysis calculates positive and negative words in defined sections. Everywhere else (in both code and text) these sections are 80 lines in length, but this one instance was talking about 100-line sections. Maybe that was the original length that was later fine-tuned to 80 lines, and this one mention was left behind.