### PR TITLE
04-word-combinations: `library(ggplot2)` invisible

### DIFF
--- a/04-word-combinations.Rmd
+++ b/04-word-combinations.Rmd
@@ -167,6 +167,9 @@ For example, the most common sentiment-associated word to follow "not" was "like
 It's worth asking which words contributed the most in the "wrong" direction. To compute that, we can multiply their score by the number of times they appear (so that a word with a score of +3 occurring 10 times has as much impact as a word with a sentiment score of +1 occurring 30 times). We visualize the result with a bar plot (Figure \@ref(fig:notwordsplot)).
 
 ```{r notwordsplot, dependson = "not_words", fig.width=8, fig.height=6, fig.cap = "The 20 words preceded by 'not' that had the greatest contribution to sentiment scores, in either a positive or negative direction"}
+
+library(ggplot2)
+
 not_words %>%
   mutate(contribution = n * score) %>%
   arrange(desc(abs(contribution))) %>%


### PR DESCRIPTION
Don't know if this is relevant (or my words/actions correct). In the past you've shown each `library()` action you need in that Section. But in this Section4 (s4.1.3 for the red-blue bar chart, etc) we can't see `'library(ggplot2)` ahead of the `ggplot()` in original row175.

(`library(ggplot2)` does exist in row111, but "echo = FALSE" in row110 means that whole bloc (rows110-125) doesn't display in s4.1.2 of [https://www.tidytextmining.com/ngrams.html] ...though Figure 4.1 does)