### PR TITLE
update url in YAML of index.Rmd

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -14,6 +14,7 @@ links-as-notes: true
 colorlinks: true
 github-repo: dgrtwo/tidy-text-mining
 cover-image: images/cover.png
+url: 'https\://www.tidytextmining.com'
 description: "A guide to text analysis within the tidy data framework, using the tidytext package and other tidy tools"
 ---
 


### PR DESCRIPTION
Hi Julia & Dave,

I am diving deep into bookdown for the Advanced R Markdown workshop at the upcoming rstudio::conf, and plugged your book's site into the online twitter card validator:

https://cards-dev.twitter.com/validator

<img width="998" alt="screen shot 2018-12-20 at 4 30 05 pm" src="https://user-images.githubusercontent.com/12160301/50318290-10242600-0475-11e9-83d1-0aa1bd11989e.png">


There is no image! But you have the `cover-image` specified, so I **think** what is missing is the `url`. Copied format from [here](https://github.com/rstudio/rmarkdown-book/blob/master/index.Rmd).

Contrast with:
<img width="1007" alt="screen shot 2018-12-20 at 4 35 06 pm" src="https://user-images.githubusercontent.com/12160301/50318330-3fd32e00-0475-11e9-9f91-6652260398de.png">

I hope this works! At the very least, it should do no harm 😇 