### PR TITLE
data_frame() soft-deprecated from tibble v2.00, replaced with tibble()

### DIFF
--- a/01-tidy-text.Rmd
+++ b/01-tidy-text.Rmd
@@ -48,7 +48,7 @@ This is a typical character vector that we might want to analyze. In order to tu
 
 ```{r text_df, dependson = "text"}
 library(dplyr)
-text_df <- data_frame(line = 1:4, text = text)
+text_df <- tibble(line = 1:4, text = text)
 
 text_df
 ```

--- a/02-sentiment-analysis.Rmd
+++ b/02-sentiment-analysis.Rmd
@@ -220,7 +220,7 @@ bing_word_counts %>%
 Figure \@ref(fig:pipetoplot) lets us spot an anomaly in the sentiment analysis; the word "miss" is coded as negative but it is used as a title for young, unmarried women in Jane Austen's works. If it were appropriate for our purposes, we could easily add "miss" to a custom stop-words list using `bind_rows()`. We could implement that with a strategy such as this.
 
 ```{r}
-custom_stop_words <- bind_rows(data_frame(word = c("miss"), 
+custom_stop_words <- bind_rows(tibble(word = c("miss"), 
                                           lexicon = c("custom")), 
                                stop_words)
 
@@ -267,7 +267,7 @@ Lots of useful work can be done by tokenizing at the word level, but sometimes i
 is a sad sentence, not a happy one, because of negation. R packages included coreNLP [@R-coreNLP], cleanNLP [@R-cleanNLP], and sentimentr [@R-sentimentr] are examples of such sentiment analysis algorithms. For these, we may want to tokenize text into sentences, and it makes sense to use a new name for the output column in such a case.
 
 ```{r PandP}
-PandP_sentences <- data_frame(text = prideprejudice) %>% 
+PandP_sentences <- tibble(text = prideprejudice) %>% 
   unnest_tokens(sentence, text, token = "sentences")
 ```
 

--- a/03-tf-idf.Rmd
+++ b/03-tf-idf.Rmd
@@ -241,7 +241,7 @@ physics %>%
 Let's remove some of these less meaningful words to make a better, more meaningful plot. Notice that we make a custom list of stop words and use `anti_join()` to remove them; this is a flexible approach that can be used in many situations. We will need to go back a few steps since we are removing words from the tidy data frame.
 
 ```{r mystopwords, dependson = "plot_physics", fig.height=7, fig.width=8, fig.cap="Highest tf-idf words in classic physics texts"}
-mystopwords <- data_frame(word = c("eq", "co", "rc", "ac", "ak", "bn", 
+mystopwords <- tibble(word = c("eq", "co", "rc", "ac", "ak", "bn", 
                                    "fig", "file", "cg", "cb", "cm"))
 physics_words <- anti_join(physics_words, mystopwords, by = "word")
 plot_physics <- physics_words %>%

--- a/05-document-term-matrices.Rmd
+++ b/05-document-term-matrices.Rmd
@@ -290,7 +290,7 @@ download_articles <- function(symbol) {
   WebCorpus(GoogleFinanceSource(paste0("NASDAQ:", symbol)))
 }
 
-stock_articles <- data_frame(company = company,
+stock_articles <- tibble(company = company,
                              symbol = symbol) %>%
   mutate(corpus = map(symbol, download_articles))
 ```

--- a/08-nasa-metadata.Rmd
+++ b/08-nasa-metadata.Rmd
@@ -54,7 +54,7 @@ Let's set up separate tidy data frames for title, description, and keyword, keep
 ```{r title, dependson = "download", message=FALSE}
 library(dplyr)
 
-nasa_title <- data_frame(id = metadata$dataset$`_id`$`$oid`, 
+nasa_title <- tibble(id = metadata$dataset$`_id`$`$oid`, 
                          title = metadata$dataset$title)
 nasa_title
 ```
@@ -62,7 +62,7 @@ nasa_title
 These are just a few example titles from the datasets we will be exploring. Notice that we have the NASA-assigned ids here, and also that there are duplicate titles on separate datasets.
 
 ```{r desc, dependson = "download", dplyr.width = 150}
-nasa_desc <- data_frame(id = metadata$dataset$`_id`$`$oid`, 
+nasa_desc <- tibble(id = metadata$dataset$`_id`$`$oid`, 
                         desc = metadata$dataset$description)
 
 nasa_desc %>% 
@@ -77,7 +77,7 @@ Now we can build the tidy data frame for the keywords. For this one, we need to 
 ```{r keyword, dependson = "download"}
 library(tidyr)
 
-nasa_keyword <- data_frame(id = metadata$dataset$`_id`$`$oid`, 
+nasa_keyword <- tibble(id = metadata$dataset$`_id`$`$oid`, 
                            keyword = metadata$dataset$keyword) %>%
   unnest(keyword)
 
@@ -131,7 +131,7 @@ We can do this by making a list of custom stop words and using `anti_join()` to 
 ```
 
 ```{r my_stopwords, dependson = "unnest"}
-my_stopwords <- data_frame(word = c(as.character(1:10), 
+my_stopwords <- tibble(word = c(as.character(1:10), 
                                     "v1", "v03", "l2", "l3", "l4", "v5.2.0", 
                                     "v003", "v004", "v005", "v006", "v7"))
 nasa_title <- nasa_title %>% 
@@ -355,7 +355,7 @@ Let’s clean up the text a bit using stop words to remove some of the nonsense 
 
 ```{r word_counts, dependson = "my_stopwords"}
 my_stop_words <- bind_rows(stop_words, 
-                           data_frame(word = c("nbsp", "amp", "gt", "lt",
+                           tibble(word = c("nbsp", "amp", "gt", "lt",
                                                "timesnewromanpsmt", "font",
                                                "td", "li", "br", "tr", "quot",
                                                "st", "img", "src", "strong",

--- a/09-usenet.Rmd
+++ b/09-usenet.Rmd
@@ -31,14 +31,14 @@ training_folder <- "data/20news-bydate/20news-bydate-train/"
 
 # Define a function to read all files from a folder into a data frame
 read_folder <- function(infolder) {
-  data_frame(file = dir(infolder, full.names = TRUE)) %>%
+  tibble(file = dir(infolder, full.names = TRUE)) %>%
     mutate(text = map(file, read_lines)) %>%
     transmute(id = basename(file), text) %>%
     unnest(text)
 }
 
 # Use unnest() and map() to apply read_folder to each subfolder
-raw_text <- data_frame(folder = dir(training_folder, full.names = TRUE)) %>%
+raw_text <- tibble(folder = dir(training_folder, full.names = TRUE)) %>%
   unnest(map(folder, read_folder)) %>%
   transmute(newsgroup = basename(folder), id, text)
 ```


### PR DESCRIPTION
When using data_frame in the example code, the following error is displayed:
`data_frame()` is deprecated, use `tibble()`.

From [tibble v2.00](https://github.com/tidyverse/tibble/releases/tag/v2.0.0), data_frame() is soft-deprecated.
* Issue: data_frame() and frame_data() are soft-deprecated, please use tibble() or tribble() ([#111](https://github.com/tidyverse/tibble/issues/111)).