### PR TITLE
Update 09-usenet.Rmd

### DIFF
--- a/09-usenet.Rmd
+++ b/09-usenet.Rmd
@@ -136,7 +136,7 @@ We can examine the top tf-idf for a few selected groups to extract words specifi
 tf_idf %>%
   filter(str_detect(newsgroup, "^sci\\.")) %>%
   group_by(newsgroup) %>%
-  top_n(12, tf_idf) %>%
+  slice_max(tf_idf, n = 12) %>%
   ungroup() %>%
   mutate(word = reorder(word, tf_idf)) %>%
   ggplot(aes(tf_idf, word, fill = newsgroup)) +
@@ -151,7 +151,7 @@ We see lots of characteristic words specific to a particular newsgroup, such as 
 plot_tf_idf <- function(d) {
   d %>%
     group_by(newsgroup) %>%
-    top_n(10, tf_idf) %>%
+    slice_max(tf_idf, n = 10) %>%
     mutate(word = reorder(word, tf_idf)) %>%
     ggplot(aes(tf_idf, word, fill = newsgroup)) +
     geom_col(show.legend = FALSE) +
@@ -228,7 +228,7 @@ What four topics did this model extract, and did they match the four newsgroups?
 sci_lda %>%
   tidy() %>%
   group_by(topic) %>%
-  top_n(8, beta) %>%
+  slice_max(beta, n = 8) %>%
   ungroup() %>%
   mutate(term = reorder_within(term, beta, topic)) %>%
   ggplot(aes(beta, term, fill = factor(topic))) +

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,6 +38,5 @@ Suggests:
   downlit,
   xml2
 Remotes:
-  rstudio/bookdown,
-  rstudio/bslib
+  rstudio/bookdown
 


### PR DESCRIPTION
Changing from `top_n()` to `slice_max()` because `top_n()` is now superseded.