### PR TITLE
update superseded tidyverse functions

### DIFF
--- a/01-tidy-text.Rmd
+++ b/01-tidy-text.Rmd
@@ -205,7 +205,7 @@ tidy_bronte %>%
 
 Interesting that "time", "eyes", and "hand" are in the top 10 for both H.G. Wells and the Brontë sisters.
 
-Now, let's calculate the frequency for each word for the works of Jane Austen, the Brontë sisters, and H.G. Wells by binding the data frames together. We can use `spread` and `gather` from tidyr to reshape our dataframe so that it is just what we need for plotting and comparing the three sets of novels.
+Now, let's calculate the frequency for each word for the works of Jane Austen, the Brontë sisters, and H.G. Wells by binding the data frames together. We can use `pivot_wider()` and `pivot_longer()` from tidyr to reshape our dataframe so that it is just what we need for plotting and comparing the three sets of novels.
 
 ```{r frequency, dependson = c("tidy_bronte", "tidy_hgwells", "tidy_books")}
 library(tidyr)
@@ -218,8 +218,11 @@ frequency <- bind_rows(mutate(tidy_bronte, author = "Brontë Sisters"),
   group_by(author) %>%
   mutate(proportion = n / sum(n)) %>% 
   select(-n) %>% 
-  spread(author, proportion) %>% 
-  gather(author, proportion, `Brontë Sisters`:`H.G. Wells`)
+  pivot_wider(names_from = author,
+              values_from = proportion) %>%
+  pivot_longer(`Brontë Sisters`:`H.G. Wells`,
+               names_to = "author",
+               values_to = "proportion")
 
 frequency
 ```

--- a/01-tidy-text.Rmd
+++ b/01-tidy-text.Rmd
@@ -218,11 +218,9 @@ frequency <- bind_rows(mutate(tidy_bronte, author = "Brontë Sisters"),
   group_by(author) %>%
   mutate(proportion = n / sum(n)) %>% 
   select(-n) %>% 
-  pivot_wider(names_from = author,
-              values_from = proportion) %>%
+  pivot_wider(names_from = author, values_from = proportion) %>%
   pivot_longer(`Brontë Sisters`:`H.G. Wells`,
-               names_to = "author",
-               values_to = "proportion")
+               names_to = "author", values_to = "proportion")
 
 frequency
 ```

--- a/02-sentiment-analysis.Rmd
+++ b/02-sentiment-analysis.Rmd
@@ -118,7 +118,7 @@ Next, we count up how many positive and negative words there are in defined sect
 The `%/%` operator does integer division (`x %/% y` is equivalent to `floor(x/y)`) so the index keeps track of which 80-line section of text we are counting up negative and positive sentiment in. 
 ```
 
-Small sections of text may not have enough words in them to get a good estimate of sentiment while really large sections can wash out narrative structure. For these books, using 80 lines works well, but this can vary depending on individual texts, how long the lines were to start with, etc. We then use `spread()` so that we have negative and positive sentiment in separate columns, and lastly calculate a net sentiment (positive - negative).
+Small sections of text may not have enough words in them to get a good estimate of sentiment while really large sections can wash out narrative structure. For these books, using 80 lines works well, but this can vary depending on individual texts, how long the lines were to start with, etc. We then use `pivot_wider()` so that we have negative and positive sentiment in separate columns, and lastly calculate a net sentiment (positive - negative).
 
 ```{r janeaustensentiment, dependson = "tidy_books"}
 library(tidyr)
@@ -126,7 +126,9 @@ library(tidyr)
 jane_austen_sentiment <- tidy_books %>%
   inner_join(get_sentiments("bing")) %>%
   count(book, index = linenumber %/% 80, sentiment) %>%
-  spread(sentiment, n, fill = 0) %>%
+  pivot_wider(names_from = sentiment,
+              values_from = n,
+              values_fill = 0) %>% 
   mutate(sentiment = positive - negative)
 ```
 
@@ -159,7 +161,7 @@ Now, we can use `inner_join()` to calculate the sentiment in different ways.
 Remember from above that the AFINN lexicon measures sentiment with a numeric score between -5 and 5, while the other two lexicons categorize words in a binary fashion, either positive or negative. To find a sentiment score in chunks of text throughout the novel, we will need to use a different pattern for the AFINN lexicon than for the other two. 
 ```
 
-Let's again use integer division (`%/%`) to define larger sections of text that span multiple lines, and we can use the same pattern with `count()`, `spread()`, and `mutate()` to find the net sentiment in each of these sections of text.
+Let's again use integer division (`%/%`) to define larger sections of text that span multiple lines, and we can use the same pattern with `count()`, `pivot_wider()`, and `mutate()` to find the net sentiment in each of these sections of text.
 
 ```{r eval=FALSE}
 afinn <- pride_prejudice %>% 
@@ -178,8 +180,10 @@ bing_and_nrc <- bind_rows(
                                          "negative"))
     ) %>%
     mutate(method = "NRC")) %>%
-  count(method, index = linenumber %/% 80, sentiment) %>%
-  spread(sentiment, n, fill = 0) %>%
+  count(method, index = linenumber %/% 80, sentiment) %>% 
+  pivot_wider(names_from = sentiment,
+              values_from = n,
+              values_fill = 0) %>% 
   mutate(sentiment = positive - negative)
 ```
 
@@ -201,7 +205,9 @@ bing_and_nrc <- bind_rows(
     ) %>%
     mutate(method = "NRC")) %>%
   count(method, index = linenumber %/% 80, sentiment) %>%
-  spread(sentiment, n, fill = 0) %>%
+  pivot_wider(names_from = sentiment,
+              values_from = n,
+              values_fill = 0) %>% 
   mutate(sentiment = positive - negative)
 ```
 

--- a/02-sentiment-analysis.Rmd
+++ b/02-sentiment-analysis.Rmd
@@ -126,9 +126,7 @@ library(tidyr)
 jane_austen_sentiment <- tidy_books %>%
   inner_join(get_sentiments("bing")) %>%
   count(book, index = linenumber %/% 80, sentiment) %>%
-  pivot_wider(names_from = sentiment,
-              values_from = n,
-              values_fill = 0) %>% 
+  pivot_wider(names_from = sentiment, values_from = n, values_fill = 0) %>% 
   mutate(sentiment = positive - negative)
 ```
 
@@ -180,7 +178,7 @@ bing_and_nrc <- bind_rows(
                                          "negative"))
     ) %>%
     mutate(method = "NRC")) %>%
-  count(method, index = linenumber %/% 80, sentiment) %>% 
+  count(method, index = linenumber %/% 80, sentiment) %>%
   pivot_wider(names_from = sentiment,
               values_from = n,
               values_fill = 0) %>% 

--- a/02-sentiment-analysis.Rmd
+++ b/02-sentiment-analysis.Rmd
@@ -268,7 +268,7 @@ This can be shown visually, and we can pipe straight into ggplot2, if we like, b
 ```{r pipetoplot, dependson = "wordcounts", fig.width=6, fig.height=3, fig.cap="Words that contribute to positive and negative sentiment in Jane Austen's novels"}
 bing_word_counts %>%
   group_by(sentiment) %>%
-  top_n(10) %>%
+  slice_max(n, n = 10) %>% 
   ungroup() %>%
   mutate(word = reorder(word, n)) %>%
   ggplot(aes(n, word, fill = sentiment)) +
@@ -373,7 +373,7 @@ tidy_books %>%
   left_join(wordcounts, by = c("book", "chapter")) %>%
   mutate(ratio = negativewords/words) %>%
   filter(chapter != 0) %>%
-  top_n(1) %>%
+  slice_max(ratio, n = 1) %>% 
   ungroup()
 ```
 

--- a/04-word-combinations.Rmd
+++ b/04-word-combinations.Rmd
@@ -437,7 +437,7 @@ This lets us pick particular interesting words and find the other words most ass
 word_cors %>%
   filter(item1 %in% c("elizabeth", "pounds", "married", "pride")) %>%
   group_by(item1) %>%
-  top_n(6) %>%
+  slice_max(correlation, n = 6) %>%
   ungroup() %>%
   mutate(item2 = reorder(item2, correlation)) %>%
   ggplot(aes(item2, correlation)) +

--- a/05-document-term-matrices.Rmd
+++ b/05-document-term-matrices.Rmd
@@ -409,9 +409,7 @@ Now that we know we can trust the dictionary to approximate the articles' sentim
 stock_sentiment_count <- stock_tokens %>%
   inner_join(get_sentiments("loughran"), by = "word") %>%
   count(sentiment, company) %>%
-  pivot_wider(names_from = sentiment,
-              values_from = n,
-              values_fill = 0)
+  pivot_wider(names_from = sentiment, values_from = n, values_fill = 0)
 
 stock_sentiment_count
 ```
@@ -420,9 +418,7 @@ stock_sentiment_count
 stock_sentiment_count <- stock_tokens %>%
   inner_join(loughran, by = "word") %>%
   count(sentiment, company) %>%
-  pivot_wider(names_from = sentiment,
-              values_from = n,
-              values_fill = 0)
+  pivot_wider(names_from = sentiment, values_from = n, values_fill = 0)
 
 stock_sentiment_count
 ```

--- a/05-document-term-matrices.Rmd
+++ b/05-document-term-matrices.Rmd
@@ -409,7 +409,9 @@ Now that we know we can trust the dictionary to approximate the articles' sentim
 stock_sentiment_count <- stock_tokens %>%
   inner_join(get_sentiments("loughran"), by = "word") %>%
   count(sentiment, company) %>%
-  spread(sentiment, n, fill = 0)
+  pivot_wider(names_from = sentiment,
+              values_from = n,
+              values_fill = 0)
 
 stock_sentiment_count
 ```
@@ -418,7 +420,9 @@ stock_sentiment_count
 stock_sentiment_count <- stock_tokens %>%
   inner_join(loughran, by = "word") %>%
   count(sentiment, company) %>%
-  spread(sentiment, n, fill = 0)
+  pivot_wider(names_from = sentiment,
+              values_from = n,
+              values_fill = 0)
 
 stock_sentiment_count
 ```

--- a/06-topic-models.Rmd
+++ b/06-topic-models.Rmd
@@ -81,24 +81,25 @@ This visualization lets us understand the two topics that were extracted from th
 
 As an alternative, we could consider the terms that had the *greatest difference* in $\beta$ between topic 1 and topic 2. This can be estimated based on the log ratio of the two: $\log_2(\frac{\beta_2}{\beta_1})$ (a log ratio is useful because it makes the difference symmetrical: $\beta_2$ being twice as large leads to a log ratio of 1, while $\beta_1$ being twice as large results in -1). To constrain it to a set of especially relevant words, we can filter for relatively common words, such as those that have a $\beta$ greater than 1/1000 in at least one topic.
 
-```{r beta_spread}
+```{r beta_wide}
 library(tidyr)
 
-beta_spread <- ap_topics %>%
+beta_wide <- ap_topics %>%
   mutate(topic = paste0("topic", topic)) %>%
-  spread(topic, beta) %>%
+  pivot_wider(names_from = topic,
+              values_from = beta) %>% 
   filter(topic1 > .001 | topic2 > .001) %>%
   mutate(log_ratio = log2(topic2 / topic1))
 
-beta_spread
+beta_wide
 ```
 
 The words with the greatest differences between the two topics are visualized in Figure \@ref(fig:topiccompare).
 
 (ref:topiccap) Words with the greatest difference in $\beta$ between topic 2 and topic 1
 
-```{r topiccompare, dependson = "beta_spread", fig.cap = "(ref:topiccap)", echo = FALSE}
-beta_spread %>%
+```{r topiccompare, dependson = "beta_wide", fig.cap = "(ref:topiccap)", echo = FALSE}
+beta_wide %>%
   group_by(direction = log_ratio > 0) %>%
   top_n(10, abs(log_ratio)) %>%
   ungroup() %>%

--- a/06-topic-models.Rmd
+++ b/06-topic-models.Rmd
@@ -57,7 +57,7 @@ ap_topics
 
 Notice that this has turned the model into a one-topic-per-term-per-row format. For each combination, the model computes the probability of that term being generated from that topic. For example, the term "aaron" has a $`r ap_topics$beta[1]`$ probability of being generated from topic 1, but a $`r ap_topics$beta[2]`$ probability of being generated from topic 2.
 
-We could use dplyr's `top_n()` to find the 10 terms that are most common within each topic. As a tidy data frame, this lends itself well to a ggplot2 visualization (Figure \@ref(fig:aptoptermsplot)).
+We could use dplyr's `slice_max()` to find the 10 terms that are most common within each topic. As a tidy data frame, this lends itself well to a ggplot2 visualization (Figure \@ref(fig:aptoptermsplot)).
 
 ```{r aptoptermsplot, dependson = "ap_topics", fig.height=4, fig.width=7, fig.cap = "The terms that are most common within each topic"}
 library(ggplot2)
@@ -65,7 +65,7 @@ library(dplyr)
 
 ap_top_terms <- ap_topics %>%
   group_by(topic) %>%
-  top_n(10, beta) %>%
+  slice_max(beta, n = 10) %>% 
   ungroup() %>%
   arrange(topic, -beta)
 
@@ -101,7 +101,7 @@ The words with the greatest differences between the two topics are visualized in
 ```{r topiccompare, dependson = "beta_wide", fig.cap = "(ref:topiccap)", echo = FALSE}
 beta_wide %>%
   group_by(direction = log_ratio > 0) %>%
-  top_n(10, abs(log_ratio)) %>%
+  slice_max(abs(log_ratio), n = 10) %>% 
   ungroup() %>%
   mutate(term = reorder(term, log_ratio)) %>%
   ggplot(aes(log_ratio, term)) +
@@ -220,12 +220,12 @@ chapter_topics
 
 Notice that this has turned the model into a one-topic-per-term-per-row format. For each combination, the model computes the probability of that term being generated from that topic. For example, the term "joe" has an almost zero probability of being generated from topics 1, 2, or 3, but it makes up `r percent(chapter_topics$beta[4])` of topic 4.
 
-We could use dplyr's `top_n()` to find the top 5 terms within each topic.
+We could use dplyr's `slice_max()` to find the top 5 terms within each topic.
 
 ```{r top_terms}
 top_terms <- chapter_topics %>%
   group_by(topic) %>%
-  top_n(5, beta) %>%
+  slice_max(beta, n = 5) %>% 
   ungroup() %>%
   arrange(topic, -beta)
 
@@ -281,7 +281,7 @@ chapters_gamma %>%
 
 We notice that almost all of the chapters from *Pride and Prejudice*, *War of the Worlds*, and *Twenty Thousand Leagues Under the Sea* were uniquely identified as a single topic each.
 
-It does look like some chapters from Great Expectations (which should be topic 4) were somewhat associated with other topics. Are there any cases where the topic most associated with a chapter belonged to another book? First we'd find the topic that was most associated with each chapter using `top_n()`, which is effectively the "classification" of that chapter.
+It does look like some chapters from Great Expectations (which should be topic 4) were somewhat associated with other topics. Are there any cases where the topic most associated with a chapter belonged to another book? First we'd find the topic that was most associated with each chapter using `slice_max()`, which is effectively the "classification" of that chapter.
 
 ```{r chapter_classifications, dependson = "chapters_gamma"}
 chapter_classifications <- chapters_gamma %>%
@@ -298,7 +298,7 @@ We can then compare each to the "consensus" topic for each book (the most common
 book_topics <- chapter_classifications %>%
   count(title, topic) %>%
   group_by(title) %>%
-  top_n(1, n) %>%
+  slice_max(n, n = 1) %>% 
   ungroup() %>%
   transmute(consensus = title, topic)
 

--- a/06-topic-models.Rmd
+++ b/06-topic-models.Rmd
@@ -86,8 +86,7 @@ library(tidyr)
 
 beta_wide <- ap_topics %>%
   mutate(topic = paste0("topic", topic)) %>%
-  pivot_wider(names_from = topic,
-              values_from = beta) %>% 
+  pivot_wider(names_from = topic, values_from = beta) %>% 
   filter(topic1 > .001 | topic2 > .001) %>%
   mutate(log_ratio = log2(topic2 / topic1))
 

--- a/07-tweet-archives.Rmd
+++ b/07-tweet-archives.Rmd
@@ -145,7 +145,7 @@ Which words are most likely to be from Julia's account or from David's account? 
 ```{r plotratios, dependson = "word_ratios", fig.width=6.5, fig.height=6, fig.cap="Comparing the odds ratios of words from our accounts"}
 word_ratios %>%
   group_by(logratio < 0) %>%
-  top_n(15, abs(logratio)) %>%
+  slice_max(abs(logratio), n = 15) %>% 
   ungroup() %>%
   mutate(word = reorder(word, logratio)) %>%
   ggplot(aes(word, logratio, fill = logratio < 0)) +
@@ -320,7 +320,7 @@ At the top of this sorted data frame, we see tweets from Julia and David about p
 word_by_rts %>%
   filter(uses >= 5) %>%
   group_by(person) %>%
-  top_n(10, retweets) %>%
+  slice_max(retweets, n = 10) %>% 
   arrange(retweets) %>%
   ungroup() %>%
   mutate(word = factor(word, unique(word))) %>%
@@ -360,7 +360,7 @@ We have built the data frames we need. Now let's make our visualization in Figur
 word_by_favs %>%
   filter(uses >= 5) %>%
   group_by(person) %>%
-  top_n(10, favorites) %>%
+  slice_max(favorites, n = 10) %>% 
   arrange(favorites) %>%
   ungroup() %>%
   mutate(word = factor(word, unique(word))) %>%

--- a/07-tweet-archives.Rmd
+++ b/07-tweet-archives.Rmd
@@ -67,14 +67,15 @@ frequency <- tidy_tweets %>%
 frequency
 ```
 
-This is a nice and tidy data frame but we would actually like to plot those frequencies on the x- and y-axes of a plot, so we will need to use `spread()` from tidyr make a differently shaped data frame.
+This is a nice and tidy data frame but we would actually like to plot those frequencies on the x- and y-axes of a plot, so we will need to use `pivot_wider()` from tidyr make a differently shaped data frame.
 
-```{r spread, dependson = "frequency"}
+```{r wide, dependson = "frequency"}
 library(tidyr)
 
 frequency <- frequency %>% 
   select(person, word, freq) %>% 
-  spread(person, freq) %>%
+  pivot_wider(names_from = person,
+              values_from = freq) %>%
   arrange(Julia, David)
 
 frequency
@@ -82,7 +83,7 @@ frequency
 
 Now this is ready for us to plot. Let's use `geom_jitter()` so that we don't see the discreteness at the low end of frequency as much, and `check_overlap = TRUE` so the text labels don't all print out on top of each other (only some will print).
 
-```{r spreadplot, dependson = "spread", fig.height=7, fig.width=7, fig.cap= "Comparing the frequency of words used by Julia and David"}
+```{r wideplot, dependson = "wide", fig.height=7, fig.width=7, fig.cap= "Comparing the frequency of words used by Julia and David"}
 library(scales)
 
 ggplot(frequency, aes(Julia, David)) +
@@ -94,7 +95,7 @@ ggplot(frequency, aes(Julia, David)) +
 ```
 
 
-Words near the line in Figure \@ref(fig:spreadplot) are used with about equal frequencies by David and Julia, while words far away from the line are used much more by one person compared to the other. Words, hashtags, and usernames that appear in this plot are ones that we have both used at least once in tweets.
+Words near the line in Figure \@ref(fig:wideplot) are used with about equal frequencies by David and Julia, while words far away from the line are used much more by one person compared to the other. Words, hashtags, and usernames that appear in this plot are ones that we have both used at least once in tweets.
 
 This may not even need to be pointed out, but David and Julia have used their Twitter accounts rather differently over the course of the past several years. David has used his Twitter account almost exclusively for professional purposes since he became more active, while Julia used it for entirely personal purposes until late 2015 and still uses it more personally than David. We see these differences immediately in this plot exploring word frequencies, and they will continue to be obvious in the rest of this chapter. 
 
@@ -108,7 +109,7 @@ tidy_tweets <- tidy_tweets %>%
          timestamp < as.Date("2017-01-01"))
 ```
 
-Next, let's use `str_detect()` to remove Twitter usernames from the `word` column, because otherwise, the results here are dominated only by people who Julia or David know and the other does not. After removing these, we count how many times each person uses each word and keep only the words used more than 10 times. After a `spread()` operation, we can calculate the log odds ratio for each word, using
+Next, let's use `str_detect()` to remove Twitter usernames from the `word` column, because otherwise, the results here are dominated only by people who Julia or David know and the other does not. After removing these, we count how many times each person uses each word and keep only the words used more than 10 times. After a `pivot_wider()` operation, we can calculate the log odds ratio for each word, using
 
 
 $$\text{log odds ratio} = \ln{\left(\frac{\left[\frac{n+1}{\text{total}+1}\right]_\text{David}}{\left[\frac{n+1}{\text{total}+1}\right]_\text{Julia}}\right)}$$
@@ -122,7 +123,9 @@ word_ratios <- tidy_tweets %>%
   group_by(word) %>%
   filter(sum(n) >= 10) %>%
   ungroup() %>%
-  spread(person, n, fill = 0) %>%
+  pivot_wider(names_from = person, 
+              values_from = n, 
+              values_fill = 0) %>%
   mutate_if(is.numeric, list(~(. + 1) / (sum(.) + 1))) %>%
   mutate(logratio = log(David / Julia)) %>%
   arrange(desc(logratio))

--- a/07-tweet-archives.Rmd
+++ b/07-tweet-archives.Rmd
@@ -74,8 +74,7 @@ library(tidyr)
 
 frequency <- frequency %>% 
   select(person, word, freq) %>% 
-  pivot_wider(names_from = person,
-              values_from = freq) %>%
+  pivot_wider(names_from = person, values_from = freq) %>%
   arrange(Julia, David)
 
 frequency
@@ -123,10 +122,8 @@ word_ratios <- tidy_tweets %>%
   group_by(word) %>%
   filter(sum(n) >= 10) %>%
   ungroup() %>%
-  pivot_wider(names_from = person, 
-              values_from = n, 
-              values_fill = 0) %>%
-  mutate(across(where(is.numeric), ~ (. + 1) / (sum(.) + 1))) %>%
+  pivot_wider(names_from = person, values_from = n, values_fill = 0) %>%
+  mutate_if(is.numeric, list(~(. + 1) / (sum(.) + 1))) %>%
   mutate(logratio = log(David / Julia)) %>%
   arrange(desc(logratio))
 ```

--- a/07-tweet-archives.Rmd
+++ b/07-tweet-archives.Rmd
@@ -126,7 +126,7 @@ word_ratios <- tidy_tweets %>%
   pivot_wider(names_from = person, 
               values_from = n, 
               values_fill = 0) %>%
-  mutate_if(is.numeric, list(~(. + 1) / (sum(.) + 1))) %>%
+  mutate(across(where(is.numeric), ~ (. + 1) / (sum(.) + 1))) %>%
   mutate(logratio = log(David / Julia)) %>%
   arrange(desc(logratio))
 ```

--- a/09-usenet.Rmd
+++ b/09-usenet.Rmd
@@ -136,7 +136,7 @@ We can examine the top tf-idf for a few selected groups to extract words specifi
 tf_idf %>%
   filter(str_detect(newsgroup, "^sci\\.")) %>%
   group_by(newsgroup) %>%
-  top_n(12, tf_idf) %>%
+  slice_max(tf_idf, n = 12) %>%
   ungroup() %>%
   mutate(word = reorder(word, tf_idf)) %>%
   ggplot(aes(tf_idf, word, fill = newsgroup)) +
@@ -151,7 +151,7 @@ We see lots of characteristic words specific to a particular newsgroup, such as 
 plot_tf_idf <- function(d) {
   d %>%
     group_by(newsgroup) %>%
-    top_n(10, tf_idf) %>%
+    slice_max(tf_idf, n  = 10) %>% 
     mutate(word = reorder(word, tf_idf)) %>%
     ggplot(aes(tf_idf, word, fill = newsgroup)) +
     geom_col(show.legend = FALSE) +
@@ -228,7 +228,7 @@ What four topics did this model extract, and did they match the four newsgroups?
 sci_lda %>%
   tidy() %>%
   group_by(topic) %>%
-  top_n(8, beta) %>%
+  slice_max(beta, n = 8) %>% 
   ungroup() %>%
   mutate(term = reorder_within(term, beta, topic)) %>%
   ggplot(aes(beta, term, fill = factor(topic))) +


### PR DESCRIPTION
the following superseded functions have been updated

`gather()` to `pivot_longer()` 
`spread()` to  `pivot_wider()`
`top_n()` to `slice_max()`
`mutate_if()` to `mutate(across(where()))`