### PR TITLE
remove extra quotation mark

### DIFF
--- a/04-word-combinations.Rmd
+++ b/04-word-combinations.Rmd
@@ -247,7 +247,7 @@ ggraph(bigram_graph, layout = "fr") +
   geom_node_text(aes(label = name), vjust = 1, hjust = 1)
 ```
 
-In Figure \@ref(fig:bigramgraph), we can visualize some details of the text structure. For example, we see that salutations such as "miss", "lady", "sir", "and "colonel" form common centers of nodes, which are often followed by names. We also see pairs or triplets along the outside that form common short phrases ("half hour", "thousand pounds", or "short time/pause").
+In Figure \@ref(fig:bigramgraph), we can visualize some details of the text structure. For example, we see that salutations such as "miss", "lady", "sir", and "colonel" form common centers of nodes, which are often followed by names. We also see pairs or triplets along the outside that form common short phrases ("half hour", "thousand pounds", or "short time/pause").
 
 We conclude with a few polishing operations to make a better looking graph (Figure \@ref(fig:bigramggraphausten2)):
 


### PR DESCRIPTION
the first quotation mark in the following highlighting is redundant, 
![image](https://user-images.githubusercontent.com/13688320/121806755-c6060f00-cc83-11eb-822e-d37c595c7fd8.png)
