### PR TITLE
`ungroup()` seems to be redundant

### DIFF
--- a/06-topic-models.Rmd
+++ b/06-topic-models.Rmd
@@ -186,8 +186,7 @@ by_chapter_word <- by_chapter %>%
 # find document-word counts
 word_counts <- by_chapter_word %>%
   anti_join(stop_words) %>%
-  count(document, word, sort = TRUE) %>%
-  ungroup()
+  count(document, word, sort = TRUE)
 
 word_counts
 ```


### PR DESCRIPTION
As mentioned in [this post](https://stackoverflow.com/a/51404538/16479803), there is no need to place `ungroup` after `count`. 
In the previous examples in the book, I have not seen `ungroup` after `count`.