### PR TITLE
Update 04-word-combinations.Rmd

### DIFF
--- a/04-word-combinations.Rmd
+++ b/04-word-combinations.Rmd
@@ -61,7 +61,7 @@ In other analyses, we may want to work with the recombined words. tidyr's `unite
 
 ```{r bigrams_united, dependson = "bigram_counts"}
 bigrams_united <- bigrams_filtered %>%
-  unite(bigram, word1, word2, sep = " ")
+  unite(bigram, word1, word2, sep = " ", na.rm = TRUE)
 
 bigrams_united
 ```


### PR DESCRIPTION
added na.rm = TRUE to the unite statement so bigrams where there is only 1 word do not have NAs in them.