### PR TITLE
Update 05-document-term-matrices.Rmd

### DIFF
--- a/05-document-term-matrices.Rmd
+++ b/05-document-term-matrices.Rmd
@@ -276,8 +276,9 @@ company <- c("Microsoft", "Apple", "Google", "Amazon", "Facebook",
 symbol  <- c("MSFT", "AAPL", "GOOG", "AMZN", "FB", 
              "TWTR", "IBM", "YHOO", "NFLX")
 
+# it appears that the Google Finance function doesn't work anymore, but the Yahoo Finance one does. Also tm.plugin.webmining doesn't seem to be supported any longer?
 download_articles <- function(symbol) {
-  WebCorpus(GoogleFinanceSource(paste0("NASDAQ:", symbol)))
+  WebCorpus(YahooFinanceSource(paste0("NASDAQ:", symbol)))
 }
 
 stock_articles <- tibble(company = company,


### PR DESCRIPTION
The textbook uses the `GoogleFinanceSource` function, but it doesn't seem like Google is supported whatever API this function uses anymore. I found a StackOverFlow thread that suggested to use `YahooFinanceSource`.

I tried it, and it works. It also appears that the `tm.plugin.webmining ` library is longer supported? Are there perhaps any other alternatives for future readers? Sorry I couldn't propose any new packages, as I'm not a developer and more of a user.

Stack Thread:
https://stackoverflow.com/questions/47790148/text-mining-with-tm-plugin-webmining-package-using-googlefinancesource-function

Cran removed package:
https://cran.r-project.org/web/packages/tm.plugin.webmining/index.html